### PR TITLE
add dependencies to fastmcp and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,38 +27,55 @@ uv run mlx_whisper_mcp.py
 ```
 
 That's it! The script will automatically install its own dependencies and start the MCP server.
+Note: The first time you run the script, it may take longer to start as it will download the Whisper model (approx. 1.6GB). Subsequent runs will be faster.
 
 ## Using with Claude Desktop
 
+There are two main ways to integrate this server with Claude Desktop:
+
+### Option 1: Using `uv` (Recommended)
+
+1.  Navigate to the directory where you've cloned or saved `mlx_whisper_mcp.py`.
+2.  Run the following command:
+    ```bash
+    uv tool run fastmcp install mlx_whisper_mcp.py
+    ```
+3.  Restart Claude Desktop if it was running. `fastmcp` will have set up the necessary configuration to launch the server, including handling its dependencies via `uv run`.
+
+### Option 2: Manual Configuration
+
+If you prefer to configure Claude Desktop manually:
+
 1. Edit your Claude Desktop configuration file:
 
-```bash
-# On macOS:
-code ~/Library/Application\ Support/Claude/claude_desktop_config.json
+   ```bash
+   # On macOS:
+   code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 
-# On Windows:
-code %APPDATA%\Claude\claude_desktop_config.json
-```
+   # On Windows:
+   code %APPDATA%\Claude\claude_desktop_config.json
+   ```
 
-2. Add the MLX Whisper MCP server configuration:
+2. Add the MLX Whisper MCP server configuration.
+   **Important:** Replace `/absolute/path/to/mlx_whisper_mcp/` in the `cwd` field below with the actual absolute path to the directory containing `mlx_whisper_mcp.py` on your system.
 
-```json
-{
-  "mcpServers": {
-    "mlx-whisper": {
-      "command": "uv",
-      "args": [
-        "--directory",
-        "/absolute/path/to/mlx_whisper_mcp/",
-        "run",
-        "mlx_whisper_mcp.py"
-      ]
-    }
-  }
-}
-```
+   ```json
+   {
+     "mcpServers": {
+       "mlx-whisper": {
+         "command": "uv",
+         "args": [
+           "run",
+           "mlx_whisper_mcp.py"
+         ],
+         "cwd": "/absolute/path/to/mlx_whisper_mcp/"
+       }
+     }
+   }
+   ```
+   This configuration tells Claude Desktop to execute `mlx_whisper_mcp.py` using `uv run`, with the current working directory (`cwd`) set to the script's location. `uv run` will handle installing the dependencies defined for the script.
 
-3. Restart Claude Desktop
+3. Restart Claude Desktop.
 
 
 ## Available Tools

--- a/mlx_whisper_mcp.py
+++ b/mlx_whisper_mcp.py
@@ -36,7 +36,7 @@ try:
 
     log.info("[green]Successfully imported mlx_whisper[/green]", extra={"markup": True})
 except ImportError:
-    log.error(
+    log.warning(
         "Error: MLX Whisper not installed. Install with 'uv pip install mlx-whisper'."
     )
 
@@ -45,10 +45,13 @@ try:
 
     log.info("[green]Successfully imported yt-dlp[/green]", extra={"markup": True})
 except ImportError:
-    log.error("Error: yt-dlp not installed. Install with 'uv pip install yt-dlp'.")
+    log.warning("Error: yt-dlp not installed. Install with 'uv pip install yt-dlp'.")
 
 
-server = FastMCP("mlx-whisper")
+server = FastMCP(
+    name = "mlx-whisper",
+    dependencies = ["mlx-whisper", "yt-dlp"]
+)
 
 MODEL_PATH = "mlx-community/whisper-large-v3-turbo"
 
@@ -81,11 +84,11 @@ async def transcribe_file(
 
         output_file = str(Path(file_path).with_suffix(".txt"))
         output_file = Path(DATA_DIR) / Path(output_file).name
-        
+
         with open(output_file, "w", encoding="utf-8") as f:
             f.write(transcript)
         log.info(f"Saving transcript to: {output_file}")
-        
+
         return f"Transcription:\n\n{transcript}"
 
     except Exception as e:


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to improve documentation and changes to `mlx_whisper_mcp.py` to enhance error messaging and dependency handling. Below are the key changes:

### Documentation Updates:
* Added a note in `README.md` explaining the initial download time for the Whisper model and provided two integration options for using the server with Claude Desktop (`uv` tool and manual configuration).
* Updated the manual configuration instructions in `README.md` to clarify how to set the `cwd` field with the absolute path to the script's directory and explained its purpose.

### Code Enhancements:
* Changed error messages in `mlx_whisper_mcp.py` for missing dependencies (`mlx-whisper` and `yt-dlp`) from `log.error` to `log.warning` to reduce severity. [[1]](diffhunk://#diff-615d99a1653af9bdf0e907252d363c9e117b69756a95244dc6060edbc26c75e8L39-R39) [[2]](diffhunk://#diff-615d99a1653af9bdf0e907252d363c9e117b69756a95244dc6060edbc26c75e8L48-R54)
* Updated the `FastMCP` server initialization in `mlx_whisper_mcp.py` to include a `dependencies` field, explicitly listing required dependencies (`mlx-whisper` and `yt-dlp`).